### PR TITLE
docs: correct CJIS v6.0 audit timeline to phased rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This script supports FedRAMP 20x compliance-as-code by producing structured, mac
 
 ## CJIS v6.0 Relevance
 
-CJIS v6.0 (audit standard from April 1, 2026) introduces a hard delta on **AU-6**: agencies handling CJI must retain audit records for **1 year** and conduct **weekly review** of those records. This script's evidence files are the unit of that retention and the input to that review. A future enhancement will add S3 archival with Object Lock (WORM compliance mode) so the 1-year retention is enforced at the storage layer, not just by file naming.
+CJIS v6.0 (published Dec 27, 2024; default audit baseline from April 1, 2026; Priority 2-4 fully enforceable Oct 1, 2027) introduces a hard delta on **AU-6**: agencies handling CJI must retain audit records for **1 year** and conduct **weekly review** of those records. This script's evidence files are the unit of that retention and the input to that review. A future enhancement will add S3 archival with Object Lock (WORM compliance mode) so the 1-year retention is enforced at the storage layer, not just by file naming.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Corrects the CJIS v6.0 audit-timeline language from a single-cutover framing ("v6.0 becomes/became the audit standard on April 1, 2026") to the verified phased rollout.
- Phased framing: v5.9.5 was the scored audit standard through March 31, 2026; v6.0 is the default audit baseline from April 1, 2026; modernized Priority 2–4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA).
- Surrounding control content (AU-6 / SC-28 / delta mappings) preserved verbatim.

## Why
The April 1, 2026 date is the default go-forward audit baseline, not a one-day enforcement cutover. The corrected framing matches the FBI CJIS v6.0 phased rollout.

## Test Plan
- [x] Dates cross-checked against the canonical reconciled CJIS v6.0 timeline
- [x] Grep sweep — zero residual single-cutover phrasing in tracked files

Factual documentation correction — no issue.